### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/src/ANSH.AspNetCore.API/ANSH.AspNetCore.API.csproj
+++ b/src/ANSH.AspNetCore.API/ANSH.AspNetCore.API.csproj
@@ -13,7 +13,15 @@
     <RepositoryUrl>$(RepositoryUrlProjectInFormation)</RepositoryUrl>
     <PublishRepositoryUrl>$(PublishRepositoryUrlProjectInFormation)</PublishRepositoryUrl>
     <LangVersion>$(LanguageVersion)</LangVersion>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>bin\Debug\netstandard$(NetstandardBase)\ANSH.AspNetCore.API.xml</DocumentationFile>

--- a/src/ANSH.AspNetCore/ANSH.AspNetCore.csproj
+++ b/src/ANSH.AspNetCore/ANSH.AspNetCore.csproj
@@ -13,7 +13,15 @@
     <RepositoryUrl>$(RepositoryUrlProjectInFormation)</RepositoryUrl>
     <PublishRepositoryUrl>$(PublishRepositoryUrlProjectInFormation)</PublishRepositoryUrl>
     <LangVersion>$(LanguageVersion)</LangVersion>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>bin\Debug\netstandard$(NetstandardBase)\ANSH.AspNetCore.xml</DocumentationFile>

--- a/src/ANSH.AutoMapper/ANSH.AutoMapper.csproj
+++ b/src/ANSH.AutoMapper/ANSH.AutoMapper.csproj
@@ -13,7 +13,15 @@
     <RepositoryUrl>$(RepositoryUrlProjectInFormation)</RepositoryUrl>
     <PublishRepositoryUrl>$(PublishRepositoryUrlProjectInFormation)</PublishRepositoryUrl>
     <LangVersion>$(LanguageVersion)</LangVersion>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>bin\Debug\netstandard$(NetstandardBase)\ANSH.AutoMapper.xml</DocumentationFile>

--- a/src/ANSH.Common/ANSH.Common.csproj
+++ b/src/ANSH.Common/ANSH.Common.csproj
@@ -13,7 +13,15 @@
     <RepositoryUrl>$(RepositoryUrlProjectInFormation)</RepositoryUrl>
     <PublishRepositoryUrl>$(PublishRepositoryUrlProjectInFormation)</PublishRepositoryUrl>
     <LangVersion>$(LanguageVersion)</LangVersion>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>bin\Debug\netstandard$(NetstandardBase)\ANSH.Common.xml</DocumentationFile>

--- a/src/ANSH.DDD.Domain.ALL/ANSH.DDD.Domain.ALL.csproj
+++ b/src/ANSH.DDD.Domain.ALL/ANSH.DDD.Domain.ALL.csproj
@@ -13,7 +13,15 @@
     <RepositoryUrl>$(RepositoryUrlProjectInFormation)</RepositoryUrl>
     <PublishRepositoryUrl>$(PublishRepositoryUrlProjectInFormation)</PublishRepositoryUrl>
     <LangVersion>$(LanguageVersion)</LangVersion>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>bin\Debug\netstandard$(NetstandardBase)\ANSH.DDD.Domain.ALL.xml</DocumentationFile>

--- a/src/ANSH.DDD.Domain.Entities.EFCore/ANSH.DDD.Domain.Entities.EFCore.csproj
+++ b/src/ANSH.DDD.Domain.Entities.EFCore/ANSH.DDD.Domain.Entities.EFCore.csproj
@@ -15,7 +15,15 @@
     <RepositoryUrl>$(RepositoryUrlProjectInFormation)</RepositoryUrl>
     <PublishRepositoryUrl>$(PublishRepositoryUrlProjectInFormation)</PublishRepositoryUrl>
     <LangVersion>$(LanguageVersion)</LangVersion>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>bin\Debug\netstandard$(NetstandardBase)\ANSH.DDD.Domain.Entities.EFCore.xml</DocumentationFile>

--- a/src/ANSH.DDD.Domain.Interface/ANSH.DDD.Domain.Interface.csproj
+++ b/src/ANSH.DDD.Domain.Interface/ANSH.DDD.Domain.Interface.csproj
@@ -15,7 +15,15 @@
     <RepositoryUrl>$(RepositoryUrlProjectInFormation)</RepositoryUrl>
     <PublishRepositoryUrl>$(PublishRepositoryUrlProjectInFormation)</PublishRepositoryUrl>
     <LangVersion>$(LanguageVersion)</LangVersion>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>bin\Debug\netstandard$(NetstandardBase)\ANSH.DDD.Domain.Interface.xml</DocumentationFile>

--- a/src/ANSH.DDD.Domain.Repository.EFCore/ANSH.DDD.Domain.Repository.EFCore.csproj
+++ b/src/ANSH.DDD.Domain.Repository.EFCore/ANSH.DDD.Domain.Repository.EFCore.csproj
@@ -15,7 +15,15 @@
     <RepositoryUrl>$(RepositoryUrlProjectInFormation)</RepositoryUrl>
     <PublishRepositoryUrl>$(PublishRepositoryUrlProjectInFormation)</PublishRepositoryUrl>
     <LangVersion>$(LanguageVersion)</LangVersion>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>bin\Debug\netstandard$(NetstandardBase)\ANSH.DDD.Domain.Repository.EFCore.xml</DocumentationFile>


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
